### PR TITLE
Implements handler for UserRegistration and consistently creates users with all required properties

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -36,6 +36,13 @@ const ZERO = BigInt.zero();
 const ONE = BigInt.fromI32(1);
 const TEN = BigInt.fromString("10");
 
+function createNewUser(userId: BigInt, userAddress: Address): User {
+    let user = new User(userId.toString());
+    user.address = userAddress;
+    user.auctions = new Array();
+    return user;
+  }
+
 export function handleAuctionCleared(event: AuctionCleared): void {
 	const auctioningTokensSold = event.params.soldAuctioningTokens;
 	const auctionId = event.params.auctionId;
@@ -278,7 +285,7 @@ export function handleNewSellOrder(event: NewSellOrder): void {
 
 	let user = User.load(userId.toString());
 	if (!user) {
-		user = new User(userId.toString());
+		user = createNewUser(userId, event.transaction.from);
 	}
 
 	let auctionDetails = AuctionDetail.load(auctionId.toString());
@@ -334,17 +341,16 @@ export function handleNewSellOrder(event: NewSellOrder): void {
 }
 
 export function handleNewUser(event: NewUser): void {
-	let userId = event.params.userId;
-	let userAddress = event.params.userAddress;
-	let user = new User(userId.toString());
-	user.address = userAddress;
-	user.auctions = new Array();
-	user.save();
+	let user = createNewUser(event.params.userId, event.params.userAddress);
+    user.save();
 }
 
 export function handleOwnershipTransferred(event: OwnershipTransferred): void {}
 
-export function handleUserRegistration(event: UserRegistration): void {}
+export function handleUserRegistration(event: UserRegistration): void {
+    let user = createNewUser(event.params.userId, event.params.user);
+    user.save();
+}
 
 export function getOrderEntityId(
 	auctionId: BigInt,


### PR DESCRIPTION
https://etherscan.io/tx/0xc0a8a715e44dcc6518925cda9cf6b55b8c51044b8cda9d6b3abfcde6cd93adea

On Apr. 29 07:46AM UTC the user 0x455f2EFA82F34bf8a81DE348a7Dc397E6Aa52035 called the method Register User which emitted the Event `UserRegistration`. Usually this function is only called internally and in that case another Event `NewUser` is being emitted aswell.
(see here:  https://github.com/FairProtocol/auction-contracts/blob/199b725eb81dac9e257b9a61e854e10ed4793116/contracts/EasyAuction.sol#L711 )
![image](https://github.com/FairProtocol/auction-graph/assets/24587026/2a9f7761-1ec9-41e8-b489-a3848ddce695)


Since the user called the method themselves the `NewUser` Event never got emitted and the subgraph is only listening for this event.
There is already a handler for the `UserRegistration` Event but it never got implemented.
This led to no user being available on the subgraph when placing a sell order and in that case the user does not get created with an address or an auctions array, which is necessary per the schema.

This pull request fixes this issue 
- creating a helper to consistently create a new user with all 
- implementing the handler for the event 
- using the helper to create a user when a sell order is placed. In that event I'm using the `transaction.from` since the userAddress is not part of the event. This makes sure that a user is always initialized correctly


We are running a [fork](https://github.com/bio-xyz/auction-graph) version of the original implementation ourselves and fixed the issue there aswell.
Our subgraph is deployed to satsuma by alchemy which crashed due to this.

AFAIK your subgraph is deployed here: https://thegraph.com/hosted-service/subgraph/aireshbhat/gnosisauctionservices?selected=logs

It seems like your subgraph successfully skipped the handler and just continued running, so the only *issue* that your subgraph has is that your are missing this user: https://etherscan.io/address/0x455f2EFA82F34bf8a81DE348a7Dc397E6Aa52035

https://api.thegraph.com/subgraphs/name/aireshbhat/gnosisauctionservices/graphql?query=query+MyQuery+%7B%0A++users+%28where%3A+%7B%0A++++address%3A+%220x455f2EFA82F34bf8a81DE348a7Dc397E6Aa52035%22%0A++%7D%29+%7B%0A++++id%0A++++auctions+%7B%0A++++++id%0A++++%7D%0A++%7D%0A%7D

As you can see in the transaction history they placed a bid. You can check our [subgraph playground](https://subgraph.satsuma-prod.com/molecule--4039244/easy-auction-mainnet/playground) with the same query as above:

```gql
{
  users (where: {
    address: "0x455f2EFA82F34bf8a81DE348a7Dc397E6Aa52035"
  })  {
    id
    auctions {
      id
    }
  }
}
```


